### PR TITLE
Fix config so wax tasks can run again

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ collections:
       source: "raw_images/keywords" # path to the directory of images within `_data`
   # Team collection used to enumerate project team members in '_team' folder
   team:
+    output: false
 
 # --------------------------------------------------------------
 # SEARCH INDEX SETTINGS


### PR DESCRIPTION
Need to update the `team` Jekyll collection. Without this, wax_tasks will always throw an error.

Note: 
* The new `output` property can be true or false, depending on whether you want stand-alone pages for team collection to be generated. For now, all team pages are rendered to the single page. Setting this to `true` would generate the overall team page, plus each page separately.
* Should probably run these tasks periodically to make sure all derivatives, pages, search data is up-to-date. If we want, we can make a GitHub Action that can run these on a schedule and update the repo automatically