### PR TITLE
Gallery card updates

### DIFF
--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -128,25 +128,23 @@
           {% endif %}
 
           <div class="gallery-item-facets {{  newClasses | join: ' ' }}  col-xl-{{min_column_width}} p-1">
-            <div class="card thumbnail-card">
-              <img
-                class="d-block card-img-top gallery-thumb w-100 mh-100"
-                src="{{ item.thumbnail | relative_url }}"
-                alt="{{ item.label }}"
-              />
-              <div class="card-body">
-                <a href="{{ item.url | relative_url }}"
-                  ><h3 class="card-title">{{ item.label }}</h3></a
-                >
+            <a href="{{ item.url | relative_url }}">
+              <div class="card thumbnail-card">
+                <!-- Item: {{ item.pid }} -->
+                <img
+                  class="d-block card-img-top gallery-thumb w-100 mh-100"
+                  src="{{ item.thumbnail | relative_url }}"
+                  alt="{{ item.label }}"
+                />
+                <div class="card-body">
+                  <h3 class="card-title">{{ item.label }}</h3>
 
-                <!-- CONSTRUCTED CARD TEXT
-        Replace the constructed text below with your own card message -->
-
-                <p class="card-text small">
-                  A {{item.object_type}} from {{item.location}} ({{item._date}}).
-                </p>
+                  <p class="card-text small">
+                    {{ item.governing_body }}, {{ item.doc_origin }} ({{ item.filing_date }})
+                  </p>
+                </div>
               </div>
-            </div>
+            </a>
           </div>
         {% endfor %}
         </div>

--- a/_layouts/facet_page_layout.html
+++ b/_layouts/facet_page_layout.html
@@ -24,6 +24,7 @@ value:
         </li>
       {% endfor %}
     </ul>
+  </div>
   
   <div class="row">
     {{content}}


### PR DESCRIPTION
Resolves #13 

# Changes

* Make the whole card clickable, instead of just the label/title
* Update caption text to include `governing_body`, `doc_origin`, `filing_date`
* Gallery size should be fixed and normalized

# Example gallery
![image](https://github.com/lxcprojects/keywords/assets/5167587/4e383910-1452-4e24-80b1-c8fdbec8ea94)
