### PR TITLE
Restrict transcription element width

### DIFF
--- a/_layouts/generic_collection_item.html
+++ b/_layouts/generic_collection_item.html
@@ -47,7 +47,7 @@ layout: default
         </div>
   {% endif %}
 
-  <div class="card-body item-metadata">
+  <div class="card-body item-metadata w-100">
 
 <!-- The block below controls the item metadata table -->
 


### PR DESCRIPTION
Resolves #27 

* Sets the width of the collection item content region, which has the consequence of preventing the offending transcription line from overflowing (it will wrap, instead)

![image](https://github.com/lxcprojects/keywords/assets/5167587/2bb67265-be74-414d-8401-308b6a5838e8)
