### PR TITLE
Pin height of gallery cards

### DIFF
--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -129,7 +129,7 @@
 
           <div class="gallery-item-facets {{  newClasses | join: ' ' }}  col-xl-{{min_column_width}} p-1">
             <a href="{{ item.url | relative_url }}">
-              <div class="card thumbnail-card">
+              <div class="card thumbnail-card h-100">
                 <!-- Item: {{ item.pid }} -->
                 <img
                   class="d-block card-img-top gallery-thumb w-100 mh-100"

--- a/_includes/subset_gallery.html
+++ b/_includes/subset_gallery.html
@@ -16,7 +16,7 @@
       <div class="row">
       {% for item in subset %}
         <div class="gallery-item {{  newClasses | join: ' ' }} col-xl-{{min_column_width}} p-1">
-            <div class='card thumbnail-card'>
+            <div class='card thumbnail-card h-100'>
               <img class='d-block card-img-top gallery-thumb w-100 mh-100' src='{{ item.thumbnail | absolute_url }}' alt="{{ item.label }}"/>
               <div class="card-body">
                 <a href="{{ item.url | absolute_url }}"><h3 class="card-title">{{ item.label }}</h3></a>


### PR DESCRIPTION
Resolves #28 

* Pins the height of the document gallery cards, applied to both the general browsing gallery and faceted sub-gallery

![image](https://github.com/lxcprojects/keywords/assets/5167587/429fa31e-42ab-4c1e-ba4c-50ffc8c646e9)
