### PR TITLE
Add sorting params to gallery

### DIFF
--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -24,6 +24,12 @@
   {% assign collection = site[include.collection] %}
 {% endif %}
 
+{% if include.sortBy and include.sortOrder == "reverse" %}
+  {% assign collection = collection | sort: include.sortBy | reverse %}
+{% elsif include.sortBy and include.sortOrder != "reverse" %}
+  {% assign collection = collection | sort: include.sortBy %}
+{% endif %}
+
 {% comment %}- END SUBSET PARSING -{% endcomment%}
 
 {% comment %} :::: FACETS :::: {% endcomment%}

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -25,6 +25,6 @@ joy and forming community.
 
 Explore a sample of the documents below.
 
-{% include gallery.html collection='keywords' facet_by='language|keywords*' num_column=4 %}
+{% include gallery.html collection='keywords' facet_by='language|keywords*' num_column=4 sortBy='filing_date' %}
 
 


### PR DESCRIPTION
* Modify the `gallery` component to take optional `sortBy` and `sortOrder` parameters
  * `sortBy` : field name to sort on, see any of the files in `_keywords/` for field names available
  * `sortOrder`: Can reverse the sorting order by setting this equal to `sortOrder="reverse"`
* Update default "collection" page to sort by `filing_date` field