### PR TITLE
Add missing manifests, update image refs

### DIFF
--- a/_keywords/d0072.md
+++ b/_keywords/d0072.md
@@ -30,6 +30,6 @@ collection: keywords
 comments:
 order: '17'
 thumbnail: "img/derivatives/iiif/images/d0072_d0072-02/full/250,/0/default.jpg"
-full: "/img/derivatives/simple/d0072_d0072-04/fullwidth.jpg"
-manifest:
+full: "img/derivatives/iiif/images/d0072_d0072-02/full/full/0/default.jpg"
+manifest: "img/derivatives/iiif/d0072/manifest.json"
 ---

--- a/_keywords/d0073.md
+++ b/_keywords/d0073.md
@@ -21,7 +21,7 @@ layout: keywords_item
 collection: keywords
 comments:
 order: '18'
-thumbnail: "img/derivatives/iiif/images/d0073/full/full/0/default.jpg"
-full: "/img/derivatives/simple/d0073/fullwidth.jpg"
-manifest:
+thumbnail: "img/derivatives/iiif/images/d0073/full/250,/0/default.jpg"
+full: "img/derivatives/iiif/images/d0073/full/full/0/default.jpg"
+manifest: "img/derivatives/iiif/d0073/manifest.json"
 ---

--- a/_keywords/d0074.md
+++ b/_keywords/d0074.md
@@ -19,7 +19,7 @@ layout: keywords_item
 collection: keywords
 comments:
 order: '19'
-thumbnail: "img/derivatives/iiif/images/d0074/full/full/0/default.jpg"
-full: "/img/derivatives/simple/d0074/fullwidth.jpg"
-manifest:
+thumbnail: "img/derivatives/iiif/images/d0074/full/250,/0/default.jpg"
+full: "img/derivatives/iiif/images/d0074/full/full/0/default.jpg"
+manifest: "img/derivatives/iiif/d0074/manifest.json"
 ---


### PR DESCRIPTION
Fixes #39 

`d0072`, `d0073`, and `d0074`:

* Manually add in missing manifest references
* Update other image references to point to IIIF images

There are some errors about missing images when using the OpenSeadragon viewer, likely some wonky image URLs in the manifests, however to my eye, it doesn't seem to be messing with the actual viewer experience. Worth looking into, though