### PR TITLE
Fix template syntax error

### DIFF
--- a/_layouts/keywords_item.html
+++ b/_layouts/keywords_item.html
@@ -19,7 +19,7 @@ meta:
   - label: 'Transcription and Translation'
     value: page.google_doc_prototype
     type: link
-    ---
+---
 
     {% comment %} Render a button for the PDF file {% endcomment %}
     {% if page.downloadable_file %}


### PR DESCRIPTION
Extra whitespace leading the `---` in the template caused the rendering of document pages to break