### PR TITLE
Custom GitHub action to generate Wax derivatives and build Jekyll site

### DIFF
--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -46,13 +46,19 @@ jobs:
 
       # Run the Wax tasks for our Keywords collections
       # This will generate pages, search index, and IIIF image derivatives
-      - name: Wax build Keywords
-        id: wax-tasks
+      - name: 'Wax build: Keywords'
+        id: wax-tasks-kw
         shell: bash
         run: |
           bundle exec rake wax:pages keywords
           bundle exec rake wax:search main
           bundle exec rake wax:derivatives:iiif keywords
+      
+      # Run Wax tasks for the 'Keywords descriptions' collection
+      # Only needs pages generated for now
+      - name: 'Wax build: Keywords descriptions'
+        shell: bash
+        run: bundle exec rake wax:pages keywords_descriptions
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default

--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -1,0 +1,77 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: '2.7.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      # Run the Wax tasks for our Keywords collections
+      # This will generate pages, search index, and IIIF image derivatives
+      - name: Wax build Keywords
+        id: wax-tasks
+        shell: bash
+        run: |
+          bundle exec rake wax:pages keywords
+          bundle exec rake wax:search main
+          bundle exec rake wax:derivatives:iiif keywords
+
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Whenever any commits are pushed onto the `main` branch, this will tell GitHub to build our Jekyll site, like before. However, this custom Action will first run the three Wax tasks before building the site.

Proof of Concept in my personal fork of this repo, where I removed all generated pages, images, and search index and the proof of concept GitHub Workflow was run to generate everything needed, build the site, and deployed

### Next steps
Once this is merged into `main` and we verify that it's running correctly (verify search and document pages are working), we can **delete**:

- `_keywords/*.md` : autogenerated pages
  - `_keywords/excerpts/*` all files here should be kept, as they hold custom data
- `search/` this folder can be removed
- `img/` folder can be removed

With current behavior, pages don't get updated when the data in the CSV is updated because Wax tasks skip pages that already exist, regardless of if they are up to date. This approach will ensure that our site will always have the most up to date data from  the CSV(s)

We will need to adjust our approach a bit when building out the site. Since these pages will no longer be part of the git history, whenever you pull changes from GitHub onto your computer, you'll have to make sure to:
1. Remove any current derivative files in these folders
2. Rerun the wax tasks to generate fresh derivative files

When we have the People Set in this site, we will need to update this YML file to run Wax tasks for that data too