### PR TITLE
Reorder tasks in GH workflow

### DIFF
--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -50,9 +50,9 @@ jobs:
         id: wax-tasks-kw
         shell: bash
         run: |
+          bundle exec rake wax:derivatives:iiif keywords
           bundle exec rake wax:pages keywords
           bundle exec rake wax:search main
-          bundle exec rake wax:derivatives:iiif keywords
       
       # Run Wax tasks for the 'Keywords descriptions' collection
       # Only needs pages generated for now


### PR DESCRIPTION
The GitHub workflow is responsible for building the Jekyll site, running the Wax tasks, and deploying to GitHub Pages. This small change forces the image derivatives to be generated first, before the pages are generated so that the correct image URLs will be present on the pages.
