### PR TITLE
Header and style changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,9 @@ search:
 menu:
   - label: "About Us"
     sub:
-      - label: "Our Team"
+      - label: "Project"
+        link: "/about/"
+      - label: "Team"
         link: "/team/"
       - label: "Contact Us"
         link: "/contact/"

--- a/_config.yml
+++ b/_config.yml
@@ -91,23 +91,22 @@ search:
 
 menu:
   - label: "About Us"
-    link: "/about/"
-  - label: "Our Team"
-    link: "/team/"
- # - label: "Documents"
- #   sub:
- #     - label: "Parallax Images"
- #       link: "/exhibits/parallax/"
- #     - label: "Image References"
- #       link: "/exhibits/references/"
- #     - label: "Subset Collection"
- #       link: "/exhibits/subset/"
-  - label: "Documents"
-    link: "/collection/"
+    sub:
+      - label: "Our Team"
+        link: "/team/"
+      - label: "Contact Us"
+        link: "/contact/"
+  - label: "Data"
+    sub:
+      - label: "Documents"
+        link: "/collection/"
+      - label: "Keywords"
+        link: "/keywords_descriptions/abuse.html"
+      - label: "People"
+        link: "/people/"
   - label: "Resources"
     link: "/resources/"
   - label: "Search"
     link: "/search/"
-  - label: "Contact Us"
-    link: "/contact/"
+
 

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -84,14 +84,16 @@
             <div class="card-body">
               {% for value in facet_values %}
               <div class="facet-item">
-                <input
-                  id="{{value | slugify}}"
-                  class="{{facet | slugify}}"
-                  type="checkbox"
-                  name="{{value}}"
-                  value="{{value}}"
-                />
-                <label for="{{value}}">{{value}}</label>
+                <label for="{{value}}">
+                  <input
+                    id="{{value | slugify}}"
+                    class="{{facet | slugify}}"
+                    type="checkbox"
+                    name="{{value}}"
+                    value="{{value}}"
+                  />
+                  {{value}}
+                </label>
               </div>
               {% endfor %}
             </div>

--- a/_layouts/facet_page_layout.html
+++ b/_layouts/facet_page_layout.html
@@ -15,8 +15,10 @@ Generate the list of nav links to all of our Keywords
     {%- if pageName != currentPage-%}
       {%- assign activeClass = "" -%}
     {%- endif -%}
-    <li class="list-group-item {{ activeClass }} py-2">
-      <a href="{{ page.url | relative_url }}">{{ page.Keyword }}</a>
+    <li class="list-group-item {{ activeClass }} p-0">
+      <a href="{{ page.url | relative_url }}">
+        <div class="py-2 px-3">{{ page.Keyword }}</div>
+      </a>
     </li>
   {% endfor %}
 {%- endcapture -%}
@@ -45,7 +47,7 @@ Generate the list of nav links to all of our Keywords
         <span class="navbar-toggler-icon">&#9776;</span>
         <h2>{{ page.label }}</h2>
       </button>
-      <div id="side-nav-sm-collapse" class="collapse navbar-collapse">
+      <div id="side-nav-sm-collapse" class="collapse navbar-collapse border-left border-right">
         <ul class="list-group list-group-flush px-4 py-2">
           {{ navs }}
         </ul>

--- a/_sass/keywords.scss
+++ b/_sass/keywords.scss
@@ -1,0 +1,38 @@
+main a {
+    color: $dark-background;
+
+    &:hover {
+        color: $dark-background;
+    }
+    &:visited {
+        color: $dark-background;
+    }
+}
+
+.banner {
+    .dropdown-item:hover {
+        color: $dark-background;
+        background-color: $light-link-hover;
+    }
+}
+
+.gallery-item-facets {
+    .card {
+        &:hover {
+            box-shadow: 0 0 5px;
+        }
+    }
+}
+
+#side-nav-sm {
+    .list-group-item-dark,
+    .list-group-item:hover {
+        background-color: $light-link-hover;
+    }
+}
+.facet-sidebar {
+    .list-group-item-dark,
+    .list-group-item:hover {
+        background-color: $light-link-hover;
+    }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -57,3 +57,4 @@ $viewer-height: 100%;
 $max-width: 100%;
 
 @import "facets";
+@import "keywords";

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -19,7 +19,7 @@ Louisiana are a deep and rich resource for Black peoples’ political practices,
 to slavery and oppression, alliances across race and status, and strategies for securing
 joy and forming community.
 
-[Search by keyword]({% link pages/docs_by/by_keyword.md %})
+[Search by keyword]({% link _keywords_descriptions/abuse.md %})
 
 Explore a sample of the documents below.
 


### PR DESCRIPTION
- Update header nav links
  - Team and Contact pages moved as subheader of About Us
  - Links to the Documents page moved as subheader of Data
  - Added links to Keywords (descriptions) and People under Data
- Adjusted link colors site wide. Green to match site theme instead of purple (which was browser default color)
- Add drop shadow on gallery cards on hover to replace the previous color change on hover
  - Card / link text would generally turn yellow on hover, which was very hard to read against our white background
- Adjusted sidebar link and background colors in the Keywords descriptions page(s)
- Dropdown inputs for Keywords and languages should be easier to press now
  - Can click the checkbox and/or on the text label for the checkbox