### PR TITLE
Feature: configurable internal link labels

### DIFF
--- a/_includes/keywords_links.html
+++ b/_includes/keywords_links.html
@@ -6,6 +6,8 @@
         - collection : (Optional) collection name that should be linked. Use name from _config.yml
                         Defaults to the current page's collection
         - delimiter : delimiter between values in `values`. Default: "|"
+        - display_field: (Optional) Which field should you use for the display label
+                            Defaults to `pid`
 {% endcomment %}
 
 {% assign collection = include.collection %}
@@ -18,6 +20,8 @@
     {% assign delimiter = "|" %}
 {% endunless %}
 
+{% assign display = include.display_field %}
+
 {% assign values = include.values | strip | split: delimiter %}
 
 {% if include.target_field %}
@@ -25,7 +29,11 @@
         {% assign key = value | strip %}
         {% assign site_data = site[include.collection] | where: include.target_field, key | first %}
         <a href="{{ site_data.url }}" class="badge badge-pill badge-info mr-1">
-            <div>{{ key }}</div>
+            {% if display %}
+                <div>{{ site_data[display] }}</div>
+            {% else %}
+                <div>{{ key }}</div>
+            {% endif %}
         </a>
     {%- endfor -%}
 {% endif %}

--- a/_includes/keywords_metadata.html
+++ b/_includes/keywords_metadata.html
@@ -28,6 +28,7 @@
               target_field=item.targetField
               collection=item.collection
               delimiter=item.delimiter
+              display_field=item.displayField
           %}
         {%- endcapture -%}
       {% endif %}

--- a/_layouts/person_description.html
+++ b/_layouts/person_description.html
@@ -28,18 +28,21 @@ meta:
     collection: keywords
     targetField: pid
     delimiter: ','
+    displayField: "label"
   - label: "Also present in"
     value: page.other_documents_present
     type: internal-link
     collection: keywords
     targetField: pid
     delimiter: ","
+    displayField: "label"
   - label: "Related to"
     value: page.related_people_ids
     type: internal-link
     collection: people
     targetField: pid
     delimiter: ","
+    displayField: "name"
   - label: "Found in stories"
     value: page.stories
   - label: "Editor"


### PR DESCRIPTION
Lets us choose the field to show on internal links.

Currently set to:
- `documents` and `other_documents_present` uses the `label` field in the CSV
- `related_people_ids` will use the `name` field in the CSV

![image](https://github.com/user-attachments/assets/d2eb17cf-b923-4f1f-aab9-f16a0a082eb9)
