### PR TITLE
Fix: related document labels on docs pages

### DIFF
--- a/_includes/keywords_links.html
+++ b/_includes/keywords_links.html
@@ -28,12 +28,20 @@
     {%- for value in values -%}
         {% assign key = value | strip %}
         {% assign site_data = site[include.collection] | where: include.target_field, key | first %}
-        <a href="{{ site_data.url }}" class="badge badge-pill badge-info mr-1">
-            {% if display %}
-                <div>{{ site_data[display] }}</div>
-            {% else %}
-                <div>{{ key }}</div>
-            {% endif %}
-        </a>
+        {% assign display_label = site_data[display] %}
+
+        {% if display != nil and display_label == nil %}
+            <span class="badge badge-pill badge-secondary mr-1">{{ key }}</span>
+        {% else %}
+            <a href="{{ site_data.url }}" class="badge badge-pill badge-info mr-1">
+                {% if display_label %}
+                    <div>{{ display_label }}</div>
+                {% else %}
+                    <div>{{ key }}</div>
+                {% endif %}
+            </a>
+        {% endif %}
+
+        
     {%- endfor -%}
 {% endif %}

--- a/_layouts/keywords_item.html
+++ b/_layouts/keywords_item.html
@@ -33,7 +33,8 @@ meta:
     type: internal-link
     collection: keywords
     targetField: pid
-    delimiter: ','
+    delimiter: ","
+    displayField: "label"
 ---
 
     {% comment %} Render a button for the PDF file {% endcomment %}


### PR DESCRIPTION
- Make sure document pages "related docs" has readable labels
- If an internal link points to data that doesn't exist, make it non-interactable and visually distinct 
![image](https://github.com/user-attachments/assets/d11b2f53-0f7b-4f20-b122-5b452adc2cea)
