### PR TITLE
Change gallery image sizes

### DIFF
--- a/_sass/keywords.scss
+++ b/_sass/keywords.scss
@@ -74,3 +74,10 @@ footer {
         width: 100px;
     }
 }
+
+// !importants in order to override Bootstrap classes
+.gallery-thumb {
+    height: initial;
+    max-height: 250px !important;
+    max-width: 250px !important;
+}


### PR DESCRIPTION
Fixes #68 

Our thumbnails are generated by Wax tasks to have a maximum size of 250 pixels in any given dimension (width/height). Because of how the images were displayed to scale up to fit the gallery card sizes, several thumbnails were scaled up in size resulting in blurry images.

- Images will no longer have consistent height. They pinned to a maximum of 250px to match the resolution of our original images, but will no longer have a minimum height to ensure that they will not be scaled

Example:
![image](https://github.com/user-attachments/assets/3ecb264b-68b9-4848-9534-b9356763f933)
