### PR TITLE
Build and deploy workflow udpates

### DIFF
--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -44,6 +44,10 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
+      # Installs ImageMagick, caches download. See https://github.com/mfinelli/setup-imagemagick
+      - name: Setup ImageMagick
+        uses: mfinelli/setup-imagemagick@v6.0.0
+
       # Run the Wax tasks for our Keywords collections
       # This will generate pages, search index, and IIIF image derivatives
       - name: 'Wax build: Keywords'

--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1.221.0
         with:
           ruby-version: '2.7.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
Fixes error(s) with our automated build-and-deploy setup in GitHub:

- Update `ruby/setup-ruby` community action
- Manually install ImageMagick

---

Seems like there was an update somewhere that broke our older version of the `setup-ruby` task and also made it so that we need to manually install ImageMagick. My best guess at the moment is that GitHub updated the underlying runners to a different version (the version of Ubuntu that ends up running our workflow) that is incompatible with the older GitHub Action we were using and adjusted some pre-installed dependencies. 