### PR TITLE
Update facet controls

### DIFF
--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -1,5 +1,5 @@
 {% comment %}- ASSIGN SEPARATOR -{% endcomment%}
-{% assign separator = "|" %}
+{% assign separator = include.separator | default: "|" %}
 
 {% comment %}- SET NUMBER OF COLUMNS -{% endcomment%}
 
@@ -36,7 +36,7 @@
 
 {% if include.facet_by %}
   <form class="row" id="facets">
-    {% assign facet_list = include.facet_by | split: "|" %}
+    {% assign facet_list = include.facet_by | split: separator %}
     {% for facet in facet_list %}
       {% comment %}- MULTI-VALUE FACETS -{% endcomment%}
       {% if facet contains "*" %}
@@ -56,49 +56,70 @@
             {% capture temp_facet_values %}{{ temp_facet_values | append: option}}|{% endcapture %}
           {% endif %}
         {% endfor %}
-        {% assign facet_values = temp_facet_values | split: "|" | uniq | sort_natural %}
+        {% assign facet_values = temp_facet_values | split: separator | uniq | sort_natural %}
+      
       {% else %}
-        {% assign facet_values = collection | map: facet | compact | uniq | sort_natural %}
+
+        {% comment %}
+          We need to flatten the facets, as facets may be single or multi-valued
+        {% endcomment %}
+
+        {% assign original_options = collection | map: facet | compact | uniq | sort_natural %}
+
+        {% assign temp_facet_values = "" %}
+        {% for option in original_options %}
+          {% if option contains separator %}
+            {% assign split_values = {{option}} | split: separator %}
+            {% for split_value in split_values %}
+              {% assign stripped_value = split_value | strip %}
+              {% capture temp_facet_values %}{{ temp_facet_values | append: stripped_value }}{{ separator }}{% endcapture %}
+            {% endfor %}
+          {% else %}
+            {% capture temp_facet_values %}{{ temp_facet_values | append: option}}{{ separator }}{% endcapture %}
+          {% endif %}
+        {% endfor %}
+        
+        {% assign facet_values = temp_facet_values | split: separator | uniq | sort_natural %}
         {% assign facet_name = facet %}
       {% endif %}
         
-        <fieldset id="{{ facet_name | slugify }}-set" class="card m-1 facet-card">
-          <div class="facet-header card-header p-0">
-            <a
-              class="facet-bn"
-              data-toggle="collapse"
-              href="#{{ facet_name | slugify }}-collapse"
-              role="button"
-              aria-expanded="false"
-              aria-controls="{{ facet_name | slugify }}-collapse"
-            >
-              <legend class="px-4 py-2">{{ facet_name | replace: "_", " " }}<span
-                  aria-hidden="true"
-                  class="facets-chevron facets-chevron-bottom float-right ml-2"
-                ></span>
-              </legend>
-            </a>
-          </div>
-          <div class="collapse" id="{{ facet_name | slugify }}-collapse">
-            {% comment %}Create Card with facet values{% endcomment %}
-            <div class="card-body">
-              {% for value in facet_values %}
-              <div class="facet-item">
-                <label for="{{ value | slugify }}">
-                  <input 
-                    id="{{value | slugify}}"
-                    class="{{facet | slugify}}"
-                    type="checkbox"
-                    name="{{value}}"
-                    value="{{value}}"
-                  />
-                  <span class="mx-2">{{value}}</span>
-                </label>
-              </div>
-              {% endfor %}
+      <fieldset id="{{ facet_name | slugify }}-set" class="card m-1 facet-card">
+        <div class="facet-header card-header p-0">
+          <a
+            class="facet-bn"
+            data-toggle="collapse"
+            href="#{{ facet_name | slugify }}-collapse"
+            role="button"
+            aria-expanded="false"
+            aria-controls="{{ facet_name | slugify }}-collapse"
+          >
+            <legend class="px-4 py-2">{{ facet_name | replace: "_", " " }}<span
+                aria-hidden="true"
+                class="facets-chevron facets-chevron-bottom float-right ml-2"
+              ></span>
+            </legend>
+          </a>
+        </div>
+        <div class="collapse" id="{{ facet_name | slugify }}-collapse">
+          {% comment %}Create Card with facet values{% endcomment %}
+          <div class="card-body">
+            {% for value in facet_values %}
+            <div class="facet-item">
+              <label for="{{ value | slugify }}">
+                <input 
+                  id="{{value | slugify}}"
+                  class="{{facet | slugify}}"
+                  type="checkbox"
+                  name="{{value}}"
+                  value="{{value}}"
+                />
+                <span class="mx-2">{{value}}</span>
+              </label>
             </div>
+            {% endfor %}
           </div>
-        </fieldset>
+        </div>
+      </fieldset>
     {% endfor %}  
   </form>
 {% else %}
@@ -107,7 +128,6 @@
 {% comment %} :::: END FACETS :::: {% endcomment%}
 
 <!-- THE GALLERY -->
-    
 <div class="wax-gallery-container full-width" id="wax-gallery-{{ include.value | slugify }}-container" >
   <div class="wax-inline-container">
       <div class="wax-gallery" id="wax-gallery-{{ include.value | slugify }}">
@@ -123,7 +143,10 @@
                   {% assign split_values = {{item_value}} | split: separator %}                 
                   {% for split_value in split_values %}
                     {% assign split_slug_value = split_value | slugify %}
-                    {% capture temp_facet_values %}{{ temp_facet_values | append: split_slug_value }}{% unless split_value == split_values.last %}|{% endunless %}{% endcapture %}
+                    {% comment %} -- Note: intentional space in the "unless" block -- {% endcomment %}
+                    {% capture temp_facet_values %}
+                      {{ temp_facet_values | append: split_slug_value }}{% unless split_value == split_values.last %} {% endunless %}
+                    {% endcapture %}
                   {% endfor %}
                 {% else %}
                   {% assign slug_value = item_value | join " " | slugify %}
@@ -132,13 +155,11 @@
                 {% assign facetArray = temp_facet_values | replace: separator, " " | split: " " %} 
                 {% assign newClasses = newClasses | concat: facetArray %}           
             {% endfor %}
-            
           {% endif %}
 
-          <div class="gallery-item-facets {{  newClasses | join: ' ' }}  col-xl-{{min_column_width}} p-1">
+          <div class="gallery-item-facets {{ newClasses | join: ' ' }} col-xl-{{min_column_width}} p-1">
             <a href="{{ item.url | relative_url }}">
               <div class="card thumbnail-card h-100">
-                <!-- Item: {{ item.pid }} -->
                 <img
                   class="d-block card-img-top gallery-thumb w-100 mh-100"
                   src="{{ item.thumbnail | relative_url }}"

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -63,7 +63,7 @@
       {% endif %}
         
         <fieldset id="{{ facet_name | slugify }}-set" class="card m-1 facet-card">
-          <div class="facet-header card-header">
+          <div class="facet-header card-header p-0">
             <a
               class="facet-bn"
               data-toggle="collapse"
@@ -72,7 +72,7 @@
               aria-expanded="false"
               aria-controls="{{ facet_name | slugify }}-collapse"
             >
-              <legend>{{ facet_name | replace: "_", " " }}<span
+              <legend class="px-4 py-2">{{ facet_name | replace: "_", " " }}<span
                   aria-hidden="true"
                   class="facets-chevron facets-chevron-bottom float-right ml-2"
                 ></span>
@@ -84,15 +84,15 @@
             <div class="card-body">
               {% for value in facet_values %}
               <div class="facet-item">
-                <label for="{{value}}">
-                  <input
+                <label for="{{ value | slugify }}">
+                  <input 
                     id="{{value | slugify}}"
                     class="{{facet | slugify}}"
                     type="checkbox"
                     name="{{value}}"
                     value="{{value}}"
                   />
-                  {{value}}
+                  <span class="mx-2">{{value}}</span>
                 </label>
               </div>
               {% endfor %}

--- a/_layouts/facet_page_layout.html
+++ b/_layouts/facet_page_layout.html
@@ -70,6 +70,7 @@ Generate the list of nav links to all of our Keywords
           field='keywords'
           value=page.Keyword
           num_column=3
+          separator=','
           display_fields="lhc_source,lhc_doc_origin,lhc_filing_date"
       %}
     {% endif %}

--- a/_sass/_facets.scss
+++ b/_sass/_facets.scss
@@ -291,7 +291,7 @@ p.card-text {
 */
 
 input[type="checkbox"] {
-  margin-right: 4px;
+  // margin-right: 4px;
 }
 
 .facet-card {

--- a/_sass/_facets.scss
+++ b/_sass/_facets.scss
@@ -290,8 +290,8 @@ p.card-text {
     (Copy the CSS below if you're importing into your own theme)
 */
 
-input[type="checkbox"] {
-  // margin-right: 4px;
+.facet-item label, input[type="checkbox"] {
+  cursor: pointer;
 }
 
 .facet-card {

--- a/assets/js/facets.js
+++ b/assets/js/facets.js
@@ -44,7 +44,6 @@ var i;
 
 for (i = 0; i < numberFacets; i++) {
   facets[setIds[i]] = new Array();
-  // console.log(facets[setIds[i]])
 }
 
 // add code that runs whenever a checkbox is turned on or off
@@ -52,22 +51,18 @@ $("#facets :checkbox").change(function () {
   // find the checkboxes parent fieldset id by taking its class name
   // and adding "-set" to the end
   var pinClass = this.className + "-set";
-  //console.log(pinClass);
 
   // find the id for this checkbox
   var pinId = this.id;
-  //console.log(pinId);
 
   // use fieldset id as key to facets object; add or remove current checkbox id
   // from the array for that key.
   if (this.checked) {
     facets[pinClass].push(pinId);
-    //console.log(facets[pinClass]);
   } else {
     facets[pinClass] = facets[pinClass].filter(function (value, index, arr) {
       return value != pinId;
     });
-    //console.log(facets[pinClass]);
   }
 
   // after updating the facets object, rerun refreshGallery()

--- a/assets/js/facets.js
+++ b/assets/js/facets.js
@@ -23,68 +23,56 @@ filters in the collection_gallery.html include.
 
 */
 
-// Set up empty object to store checkbox selections
-var facets = {};
+// Selected facets
+let facets = {};
 
-// Set up empty array to store the ids of each facet fieldset
-var setIds = [];
+// IDs of each facet fieldset
+let setIds = [];
 
 $("fieldset").each(function (i, e) {
   setIds.push(e.id);
 });
 
-// Count the number of fieldsets on the page
-var numberFacets = setIds.length;
+// Number of fieldsets on the page
+const numberFacets = setIds.length;
 
-// Set up a 'for' loop to run through the fieldset ids and
-// use each of them as a key for the 'facets' object. Each
-// key gets an empty array, which will be used to store
-// currently active checkboxes in that fieldset.
-var i;
-
-for (i = 0; i < numberFacets; i++) {
+// Use each of them as a key for the 'facets' object. Each key gets an empty array,
+// which will be used to store currently active checkboxes in that fieldset.
+for (let i = 0; i < numberFacets; i++) {
   facets[setIds[i]] = new Array();
 }
 
-// add code that runs whenever a checkbox is turned on or off
 $("#facets :checkbox").change(function () {
-  // find the checkboxes parent fieldset id by taking its class name
-  // and adding "-set" to the end
-  var pinClass = this.className + "-set";
+  // Find the checkboxes parent fieldset id by taking its class name and adding "-set" to the end
+  const pinClass = `${this.className}-set`;
 
-  // find the id for this checkbox
-  var pinId = this.id;
-
-  // use fieldset id as key to facets object; add or remove current checkbox id
+  // Use fieldset id as key to facets object; add or remove current checkbox id
   // from the array for that key.
   if (this.checked) {
-    facets[pinClass].push(pinId);
+    facets[pinClass].push(this.id);
   } else {
-    facets[pinClass] = facets[pinClass].filter(function (value, index, arr) {
-      return value != pinId;
-    });
+    facets[pinClass] = facets[pinClass].filter((value) => value != this.id);
   }
 
-  // after updating the facets object, rerun refreshGallery()
+  // After updating the facets object, rerun refreshGallery()
   refreshGallery();
 });
 
+/**
+ * Shows / hides items based on active checkboxes
+ */
 function refreshGallery() {
-  // this function shows and hides gallery items based on active checkboxes
+  // Grab all gallery items
+  let listOfElements = $(".gallery-item-facets");
 
-  // grab all gallery items
-  var listOfElements = $(".gallery-item-facets");
-
-  // start by clearing the gallery of all items
+  // Start by clearing the gallery of all items
   listOfElements.hide("slow");
 
-  // starting with the full list of all elements, loop through each fieldset
+  // Starting with the full list of all elements, loop through each fieldset
   // one at a time and keep only the elements that have one or more of the
   // desired values (based on checkboxes)
   // - loop through each fieldset in facets
-  // - if the array is empty (e.g., no checkboxes checked), take all possible
-  //   values in that fieldset and treat them as valid by including them in the
-  //   list of desired values
+  // - if the array is empty (e.g., no checkboxes checked), show all items
   // - if the array is not empty (e.g., one or more checkboxes checked),
   //   add only the items from the array to the list of desired values
   // - in both cases, add a "." before the checkbox id so it can be used as a
@@ -95,16 +83,14 @@ function refreshGallery() {
   // - filter the running list of elements to exclude elements that have none
   //   of the specified classes
   // - after finishing the for loop, take all remaining elements and show them
-  for (i = 0; i < numberFacets; i++) {
-    var inputIds = [];
+  for (let i = 0; i < numberFacets; i++) {
+    let inputIds = [];
     if (facets[setIds[i]].length == 0) {
-      $(`#${setIds[i]} input`).each(function (i, e) {
-        inputIds.push("." + e.id);
-      });
+      // When no facets selected, instead of filtering by facet class
+      // This will show everything including items that don't have any facet-set class
+      inputIds.push('.gallery-item-facets');
     } else {
-      inputIds = facets[setIds[i]].map(function (el) {
-        return "." + el;
-      });
+      inputIds = facets[setIds[i]].map((id) => "." + id );
     }
     listOfClasses = inputIds.join(",");
     listOfElements = listOfElements.filter($(`${listOfClasses}`));

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -29,6 +29,7 @@ Explore a sample of the documents below.
     facet_by='language'
     num_column=4
     sortBy='filing_date'
+    separator=','
     display_fields="lhc_source,lhc_doc_origin,lhc_filing_date"
 %}
 


### PR DESCRIPTION
Fixes #92 

## Changes: 

- Removes duplicate facet values when they may be introduced by multi-valued fields
- Expands the interactable area of the facet button and checkboxes
- Fixes issue where items with no value in the facet field would never reappear when clearing facet filter

![image](https://github.com/user-attachments/assets/ebbdb113-a80f-426d-a6f1-336e661187a7)

## Testing

I highly recommend testing this out on your computer, since I find reading Liquid templates a bit annoying.

- Checkout this branch: `git checkout 92-update-facet-controls`
- There are no CSV changes, so I'm assuming you already have the pages, image derivatives already in place
- Start up the Jekyll dev server: `bundle exec jekyll serve`
- Navigate to the site in your browser: http://localhost:4000/collection/
- Check the language facets behavior
