### PR TITLE
Cache image derivatives step in build automation

### DIFF
--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -48,13 +48,29 @@ jobs:
       - name: Setup ImageMagick
         uses: mfinelli/setup-imagemagick@v6.0.0
 
+      # Cache image derivs, because they take a long time to generate
+      # Single images and images in folders are matched
+      # jp*g is used to glob match jpg and jpeg
+      - name: 'Cache image derivatives'
+        id: cache-image-derivs
+        uses: actions/cache@v4
+        with:
+          path: img/
+          key: ${{ runner.os }}-image-derivatives-${{ hashFiles('_data/raw_images/keywords/*.jp*g', '_data/raw_images/keywords/**/*.jp*g') }}
+      
+      # Generate image derivatives if cache is not found
+      - name: 'Generate IIIF image derivatives'
+        id: gen-img-derivs
+        if: steps.cache-image-derivs.outputs.cache.hit != 'true'
+        shell: bash
+        run: bundle exec rake wax:derivatives:iiif keywords
+
       # Run the Wax tasks for our Keywords collections
       # This will generate pages, search index, and IIIF image derivatives
       - name: 'Wax build: Keywords'
         id: wax-tasks-kw
         shell: bash
         run: |
-          bundle exec rake wax:derivatives:iiif keywords
           bundle exec rake wax:pages keywords
           bundle exec rake wax:search main
       


### PR DESCRIPTION
Add a step in the build-and-deploy automation that will cache the IIIF image derivatives that are created during the build. Subsequent pushes to main will be able to download this cache instead of needing to regenerate the image derivatives. Cache becomes invalid if there are any changes to `_data/raw_images/` (new or updated images) or if the cache hasn't been used for too long.

GitHub has a default policy of these caches living for a maximum of 7 days after last access, so if there are no builds in this repository for a week or more, then the cache goes away. New builds after this will need to generate and re-cache the image derivatives.