### PR TITLE
Keywords (glossary) searchablility

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,14 @@ search:
           - lhc_doc_type
           - keywords
           - abstract
+      keywords_descriptions:
+        content: false
+        fields:
+          - pid
+          - label
+          - Keyword
+          - Description
+          - "Main Bias Set Records"
 
 # --------------------------------------------------------------
 # SITE MENU SETTINGS

--- a/_sass/_facets.scss
+++ b/_sass/_facets.scss
@@ -151,7 +151,7 @@ a.action-button:hover {
         img {
           float: left;
         }
-        p {
+        p, div {
           margin: 0 !important;
           padding: 0;
           .title {

--- a/assets/js/search-ui.js
+++ b/assets/js/search-ui.js
@@ -18,23 +18,37 @@ function getThumbnail(item, url) {
   }
 }
 
+function getSnippet(item, fields, metadata) {
+  return metadata
+    .filter(subtitle => fields.includes(subtitle) && item[subtitle])
+    .map((subtitle) => {
+      let label = subtitle.replaceAll('_', ' ');
+      label = `${label.charAt(0).toUpperCase()}${label.slice(1)}`
+      return `<b>${label}</b>: ${item[subtitle]}`;
+    })
+    .join(' | ');
+}
+
 function displayResult(item, fields, url, subtitles) {
   var pid   = item.pid;
   var label = item.label || 'Untitled';
   var link  = item.permalink;
   var thumb = getThumbnail(item, url);
 
-  var meta = subtitles
-    .filter(subtitle => fields.includes(subtitle))
-    .map((subtitle) => {
-      let label = subtitle.replaceAll('_', ' ');
-      label = `${label.charAt(0).toUpperCase()}${label.slice(1)}`
-      return `<b>${label}</b>: ${item[subtitle]}`;
-    })
-    .join(' | ')
-
-  // note: href below not working on localhost
-  return `<div class="result"><a href="..${link}">${thumb}<p><span class="title">${item.label}</span><br><span class="meta">${meta}</span></p></a></div>`;
+  const result = `
+  <div class="result">
+    <a class="result-link" href="${link}">
+      <span class="result-thumbnail">${thumb}</span>
+      <div class="w-100">
+        <div class="title">${item.label}</div>
+        <div class="meta text-truncate">
+          ${getSnippet(item, fields, subtitles)}
+        </div>
+      </div>
+    </a>
+  </div>
+  `;
+  return result;
 }
 
 function startSearchUI(fields, indexFile, url, subtitles) {
@@ -44,8 +58,8 @@ function startSearchUI(fields, indexFile, url, subtitles) {
     index.saveDocument(false);
     index.setRef('lunr_id');
 
-    for (i in fields) { index.addField(fields[i]); }
-    for (i in store)  { index.addDoc(store[i]); }
+    for (let i in fields) { index.addField(fields[i]); }
+    for (let i in store)  { index.addDoc(store[i]); }
 
     $('input#search').on('keyup', function() {
       var results_div = $('#results');

--- a/pages/search.md
+++ b/pages/search.md
@@ -4,4 +4,4 @@ title: Search the Collection
 permalink: /search/
 ---
 
-{% include search_box.html search='main' subtitle='lhc_filing_date' %}
+{% include search_box.html search='main' subtitle='lhc_filing_date,Description' %}


### PR DESCRIPTION
Fixes #93 

## Changes

- Add keywords to search index and make them searchable
  - Adjusted in `_config.json`, we can change which fields are searched
  - This change will search through fields: pid, label, Keyword, Description, and "Main Bias Set Records"
- Adjust results display a bit to not show undefined fields in results snippet
  - E.g. a Keyword has no `lhc_filing_date` field, but has a Description, so hide the filing date and show Description for those

![image](https://github.com/user-attachments/assets/1eb8aac2-7cf1-4682-93c8-e58cbe687436)
Note: Term "crime" entered in search box. The "Crime & Punishment" keyword is top result. Wellness has the word "crime" appear several times in its description.

##  Search configurability

**Question for the team:**

We need to determine what we want the search result to look like in order to know what the ultimate configuration will be. We can add or take out fields from the search index. Doing so will give or take away the ability to search within those fields, but it also determines whether the field is available in the search result preview. As a hypothetical, if we do not want to search within the keyword description, e.g. we don't want to match the word "crime" in the description of "Wellness" then we would not index the Description field. This would result in the Wellness keyword not appearing in the example search above, we would also not be able to show the snippet of the description in the results list.

## Next steps

I think this is a good first step to updating the search on the website. However, when we search for a keyword, do we want to bring up all documents that have this keyword? This will take more investigation.
