### PR TITLE
Editing the <u> HTML on d0111.md

### DIFF
--- a/_keywords/excerpts/d0111.md
+++ b/_keywords/excerpts/d0111.md
@@ -17,7 +17,7 @@ contra D.n Salomon Prevot Sobre que Se
 atime á Juan Pedro aliaz Bonhome Su her  
 mano para Su Livertad_____  
   
-</u>N.<sup>o</sup> 145_</u>  
+<u>N.<sup>o</sup> 145_</u>  
   
 Juez el S<sup>or</sup>   
 Gov.or  \}  


### PR DESCRIPTION
It currently looks like "</the letter u>" N.o 145_"</the letter u>" on the website. I took a stab at trying to edit the HTML to be an underline. https://docs.k4bl.org/keywords/d0111.html
<img width="1297" alt="Screenshot 2025-05-16 at 3 49 19 PM" src="https://github.com/user-attachments/assets/b7a9a590-2dd9-4a23-aeaf-45137e3d1bdd" />
