### PR TITLE
Add keywords to gallery cards

### DIFF
--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -74,12 +74,14 @@
               {% assign stripped_value = split_value | strip %}
               {% capture temp_facet_values %}{{ temp_facet_values | append: stripped_value }}{{ separator }}{% endcapture %}
             {% endfor %}
+{% comment %}
           {% elsif option contains "|" %}
             {% assign split_values = {{option}} | split: "|" %}
             {% for split_value in split_values %}
               {% assign stripped_value = split_value | strip %}
               {% capture temp_facet_values %}{{ temp_facet_values | append: stripped_value }}{{ separator }}{% endcapture %}
             {% endfor %}
+{% endcomment %}
           {% else %}
             {% capture temp_facet_values %}{{ temp_facet_values | append: option}}{{ separator }}{% endcapture %}
           {% endif %}

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -74,6 +74,12 @@
               {% assign stripped_value = split_value | strip %}
               {% capture temp_facet_values %}{{ temp_facet_values | append: stripped_value }}{{ separator }}{% endcapture %}
             {% endfor %}
+          {% elsif option contains "|" %}
+            {% assign split_values = {{option}} | split: "|" %}
+            {% for split_value in split_values %}
+              {% assign stripped_value = split_value | strip %}
+              {% capture temp_facet_values %}{{ temp_facet_values | append: stripped_value }}{{ separator }}{% endcapture %}
+            {% endfor %}
           {% else %}
             {% capture temp_facet_values %}{{ temp_facet_values | append: option}}{{ separator }}{% endcapture %}
           {% endif %}
@@ -172,7 +178,7 @@
                     {% assign display_fields = include.display_fields | split: "," %}
                     {% for df in display_fields %}
                       {% if item[df] %}
-                        <div class="card-text small">
+                        <div class="card-text small mb-2">
                           {{ item[df] }}
                         </div>
                       {% endif %}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,6 +1,8 @@
 // Centralized variables migrated from assets/css/style.scss
 // Use this module in other partials: @use "variables" as *;
 
+$k4bl-primary-color: #005442;
+
 /* text */
 
 $body-font: "Open Sans Regular", "Verdana", "sans-serif";

--- a/_sass/collection.scss
+++ b/_sass/collection.scss
@@ -1,0 +1,11 @@
+// Browse Document
+@use "variables" as *;
+
+#browse-keywords-btn {
+  color: $k4bl-primary-color;
+  font-size: 1.2rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/_sass/keywords.scss
+++ b/_sass/keywords.scss
@@ -1,4 +1,5 @@
 @use "variables" as *;
+@use "collection.scss";
 
 main {
     a:not(.badge) {

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -4,6 +4,7 @@ title: The Documents
 gallery: True
 permalink: /collection/
 ---
+{% comment %} For styles specific to this page, see "_sass/collection.scss" {% endcomment %}
 
 “Kinship and Belonging: Reimagining the Place of Black Life in the Louisiana Colonial
 Archive" recasts the story of Africans and people of African descent through the
@@ -19,7 +20,7 @@ Louisiana are a deep and rich resource for Black peoples’ political practices,
 to slavery and oppression, alliances across race and status, and strategies for securing
 joy and forming community.
 
-<a class="btn" href="{{ '/keywords_descriptions' | absolute_url }}">
+<a id="browse-keywords-btn" class="btn pl-0" href="{{ '/keywords_descriptions' | absolute_url }}">
     Browse by keyword
 </a>
 

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -26,10 +26,10 @@ Explore a sample of the documents below.
 {% include
     gallery.html
     collection='keywords'
-    facet_by='language'
+    facet_by='language,keywords'
     num_column=4
     sortBy='filing_date'
     separator=','
-    display_fields="lhc_source,lhc_doc_origin,lhc_filing_date"
+    display_fields="lhc_source,lhc_doc_origin,lhc_filing_date,keywords"
 %}
 

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -19,7 +19,9 @@ Louisiana are a deep and rich resource for Black peoples’ political practices,
 to slavery and oppression, alliances across race and status, and strategies for securing
 joy and forming community.
 
-[Browse by keyword.]({% link _keywords_descriptions/abuse.md %})
+<a class="btn" href="{{ '/keywords_descriptions' | absolute_url }}">
+    Browse by keyword
+</a>
 
 Explore a sample of the documents below.
 

--- a/pages/collection.md
+++ b/pages/collection.md
@@ -26,7 +26,7 @@ Explore a sample of the documents below.
 {% include
     gallery.html
     collection='keywords'
-    facet_by='language,keywords'
+    facet_by='language'
     num_column=4
     sortBy='filing_date'
     separator=','


### PR DESCRIPTION
Naively add keywords in document to cards in the gallery
- _Note: Adding a dropdown filter won't easily work with the current data format_

<img width="1359" height="1293" alt="image" src="https://github.com/user-attachments/assets/a144b7d7-1110-42d8-854b-dda21b190a43" />
