### PR TITLE
Add support for formatted titles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ search:
         fields: # the metadata fields to index
           - pid
           - label
+          - label_plain
           - lhc_filing_date
           - full_index
           - lhc_doc_origin

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -166,7 +166,7 @@
                   alt="{{ item.label }}"
                 />
                 <div class="card-body">
-                  <h3 class="card-title">{{ item.label }}</h3>
+                  <h3 class="card-title">{{ item.label | markdownify }}</h3>
 
                   {% if include.display_fields %}
                     {% assign display_fields = include.display_fields | split: "," %}

--- a/assets/js/search-ui.js
+++ b/assets/js/search-ui.js
@@ -22,11 +22,28 @@ function getSnippet(item, fields, metadata) {
   return metadata
     .filter(subtitle => fields.includes(subtitle) && item[subtitle])
     .map((subtitle) => {
+      // debugger
       let label = subtitle.replaceAll('_', ' ');
       label = `${label.charAt(0).toUpperCase()}${label.slice(1)}`
       return `<b>${label}</b>: ${item[subtitle]}`;
     })
     .join(' | ');
+}
+
+/**
+ * Naive markdown "parsing"
+ * For robust markdown handling, consider bringing in an external library
+ * e.g. Marked JS
+ */
+function renderMarkdown(md = '') {
+  const escapeHtml = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return escapeHtml(md)
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/_(.+?)_/g, '<em>$1</em>')
+    .replace(/`(.+?)`/g, '<code>$1</code>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\n/g, '<br>');
 }
 
 function displayResult(item, fields, url, subtitles) {
@@ -40,7 +57,7 @@ function displayResult(item, fields, url, subtitles) {
     <a class="result-link" href="${link}">
       <span class="result-thumbnail">${thumb}</span>
       <div class="w-100">
-        <div class="title">${item.label}</div>
+        <div class="title">${renderMarkdown(label)}</div>
         <div class="meta text-truncate">
           ${getSnippet(item, fields, subtitles)}
         </div>


### PR DESCRIPTION
**This does not include the updated CSV** We first need to make sure the updated CSV with `label_plain` will be part of the `keywords.csv` from either Airtable or as part of the transforms that output the website CSV.

## Changes

- Add `label_plain` to keywords site config
- Update search to use `label_plain` for searching
- Force the search UI to render the formatted label
