### PR TITLE
Add Umami analytics tracking script

### DIFF
--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -75,9 +75,19 @@ jobs:
           bundle exec rake wax:pages people
           bundle exec rake wax:search main
 
+      - name: Inject analytics config
+        if: ${{ vars.UMAMI_WEBSITE_ID != '' }}
+        run: |
+          echo "umami_website_id: \"${{ vars.UMAMI_WEBSITE_ID }}\"" > _config_analytics.yml
+
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: |
+          if [ -f _config_analytics.yml ]; then
+            bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --config _config.yml,_config_analytics.yml
+          else
+            bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+          fi
         env:
           JEKYLL_ENV: production
 

--- a/README.md
+++ b/README.md
@@ -139,3 +139,10 @@ Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapi
 ```
 
 This example will add the following to the list of Keywords Alumni: ![Sample team member entry](/assets/figures/example-team-entry.png)
+
+## Analytics
+
+We've added integration with the open source analytics platform [Umami](https://umami.is/). Despite our website's minimal compute context, it is best to use the Umami hosted script in order to keep up to date with any Umami changes without need for manual intervention, especially since this script is not strictly necessary for website functionality.
+
+The ID needed for Umami analytics tracking is only added to the website when it is built and published to GitHub Pages - it will not be included during deployment builds, such as when running Jekyll locally during development. If we need to update the Umami website ID, it can be found in the GitHub repository `Settings > Secrets and variables > Actions > Repository variables`
+

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,5 +28,10 @@
   <script type='text/javascript' src='{{ "/assets/js/jquery/jquery-3.7.1.min.js" | absolute_url }}'></script>
   {% if page.gallery %}<script type='text/javascript' defer src='{{ "/assets/js/facets.js" | absolute_url }}'></script>{% endif %}
   <script type='text/javascript' defer src='{{ "/assets/js/bootstrap/4.6.2/bootstrap.min.js" | absolute_url }}'></script>
+  {% if jekyll.environment == "production" and site.umami_website_id %}
+  <!-- Umami analytics -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="{{ site.umami_website_id }}"></script>
+  {% endif %}
+
   <noscript><p>Please enable JavaScript in your browser.</p></noscript>
 </head>


### PR DESCRIPTION
## Changes

- Add Umami script to website to enable analytics tracking
- Add website ID as a GitHub repository variable

## Notes

- Umami tracking script only added for production builds AND if the umami_website_id is defined in the site config. This can be verified locally by creating a test config file `echo "umami_website_id: \"hello world\"" > _test.yml` then running a production build locally: `JEKYLL_ENV:production bundle exec jekyll build --config _config.yml,_test.yml`. This will build the website in production mode and include the default configuration file with the new test configuration file that includes the correct variable. Once done, check `_site/index.html` and you should see the Umami tracking script added in the HTML head. 
- Website ID is not secret, but we only want it included in our production `docs.k4bl.org` website, not forks or the prototype site or development deployments. We don't want to accidentally track traffic outside of our website.

