### PR TITLE
Manually setup ImageMagick

### DIFF
--- a/.github/imagemagick-policy.xml
+++ b/.github/imagemagick-policy.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)*>
+<!ATTLIST policymap xmlns CDATA #FIXED "">
+<!ELEMENT policy EMPTY>
+<!ATTLIST policy xmlns CDATA #FIXED "">
+<!ATTLIST policy domain NMTOKEN #REQUIRED>
+<!ATTLIST policy name NMTOKEN #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy rights NMTOKEN #IMPLIED>
+<!ATTLIST policy stealth NMTOKEN #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Web-safe ImageMagick security policy for CI builds.
+
+  Only web-safe image formats (GIF, JPEG, PNG, WEBP) are permitted.
+  All external delegates, filters, and indirect reads are disabled.
+
+  See: https://imagemagick.org/source/policy-websafe.xml
+-->
+<policymap>
+  <!-- Resource limits -->
+  <policy domain="resource" name="thread" value="2"/>
+  <policy domain="resource" name="time" value="120"/>
+  <policy domain="resource" name="file" value="768"/>
+  <policy domain="resource" name="memory" value="256MiB"/>
+  <policy domain="resource" name="map" value="512MiB"/>
+  <policy domain="resource" name="area" value="16KP"/>
+  <policy domain="resource" name="disk" value="1GiB"/>
+  <policy domain="resource" name="list-length" value="16"/>
+  <policy domain="resource" name="width" value="8KP"/>
+  <policy domain="resource" name="height" value="8KP"/>
+  <policy domain="resource" name="throttle" value="2"/>
+  <!-- Memory and cache hardening -->
+  <policy domain="cache" name="memory-map" value="anonymous"/>
+  <policy domain="cache" name="synchronize" value="true"/>
+  <!-- Disable all external delegates -->
+  <policy domain="delegate" rights="none" pattern="*"/>
+  <!-- Disable all image filters -->
+  <policy domain="filter" rights="none" pattern="*"/>
+  <!-- Block stdin/stdout and sensitive paths -->
+  <policy domain="path" rights="none" pattern="-"/>
+  <policy domain="path" rights="none" pattern="fd:*"/>
+  <policy domain="path" rights="none" pattern="/etc/*"/>
+  <policy domain="path" rights="none" pattern="*../*"/>
+  <!-- Disable indirect reads (e.g. @filename) -->
+  <policy domain="path" rights="none" pattern="@*"/>
+  <!-- Deny all image modules, then allow only web-safe formats -->
+  <policy domain="module" rights="none" pattern="*"/>
+  <policy domain="module" rights="read | write" pattern="{GIF,JPEG,PNG,WEBP}"/>
+  <!-- Shred memory buffers on free -->
+  <policy domain="system" name="shred" value="1"/>
+  <policy domain="system" name="memory-map" value="anonymous"/>
+  <policy domain="system" name="max-memory-request" value="256MiB"/>
+</policymap>

--- a/.github/workflows/build-keywords.yml
+++ b/.github/workflows/build-keywords.yml
@@ -25,6 +25,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+env:
+  IMAGEMAGICK_VERSION: '7.1.2-26'
+
 jobs:
   # Build job
   build:
@@ -44,9 +47,30 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
-      # Installs ImageMagick, caches download. See https://github.com/mfinelli/setup-imagemagick
+      - name: Cache ImageMagick binary
+        id: cache-imagemagick
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/magick
+          key: ${{ runner.os }}-imagemagick-${{ env.IMAGEMAGICK_VERSION }}
+
       - name: Setup ImageMagick
-        uses: mfinelli/setup-imagemagick@v6.0.0
+        if: steps.cache-imagemagick.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o magick.appimage "https://github.com/ImageMagick/ImageMagick/releases/download/${IMAGEMAGICK_VERSION}/ImageMagick-${IMAGEMAGICK_VERSION}-gcc-x86_64.AppImage"
+          chmod +x magick.appimage
+          sudo mv magick.appimage /usr/local/bin/magick
+
+      - name: Configure ImageMagick security policy
+        run: |
+          POLICY_DIR="$HOME/.config/ImageMagick"
+          mkdir -p "$POLICY_DIR"
+          cp .github/imagemagick-policy.xml "$POLICY_DIR/policy.xml"
+
+      - name: Verify ImageMagick
+        run: |
+          magick --version
+          magick -list policy
 
       # Cache image derivs, because they take a long time to generate
       # Single images and images in folders are matched


### PR DESCRIPTION
This should sidestep the current error we are encountering in the website build automation. Tested on the prototype site: https://github.com/jabrah/keywords/actions/runs/28395707394/job/84133795258

- Remove the previous "setup-imagemagick" GitHub community action
- Add a few steps to our workflow to download and setup ImageMagick with a pinned version
  - Version set with environment variable (not yet able to specify on workflow runs)
- Add a security policy for ImageMagick execution in GitHub